### PR TITLE
Enhance/markov chain

### DIFF
--- a/docs/stochastic-methods.md
+++ b/docs/stochastic-methods.md
@@ -339,3 +339,42 @@ markov.chain(10);
 // clear the model
 markov.clear();
 ```
+
+### Deep Markov Chain
+
+This is an identical approach to the [Markov Chain](#markov-chain) while also offering the possibility of training to create n-length chains. In theory, longer chains preserve the original structure of the model, but won't generate as diverse outputs.
+
+```js
+const Rand = require('total-serialism').Stochastic;
+
+var pattern = [1, 2, 3, 4, 5];
+// make a MarkovChain instance and optionally train with array
+let markov = new Rand.MarkovChain(pattern, 2);
+
+// view the transition table (stored as Map())
+// Keys are stored as stringis derived via JSON.stringify()
+console.log(markov.table);
+// {
+// 	'[1,2]' : [3],
+// 	'[2,3]' : [4],
+// 	'[3,4]' : [5],
+// 	'[4,5]' : [6]
+// }
+
+// set the state of the model used as initial value
+markov.state([1, 2]);
+
+// set the seed for the scoped random number generator
+markov.seed(31415);
+
+// go to the next state based on the model probabilities
+markov.next();
+// => [3]
+
+// generate an array of 10 values 
+markov.chain(3);
+// => [[3], [4], [5]]
+
+// clear the model
+markov.clear();
+```

--- a/docs/stochastic-methods.md
+++ b/docs/stochastic-methods.md
@@ -23,6 +23,7 @@ const Rand = require('total-serialism').Stochastic;
 - [clave](#clave)
 - [expand](#expand)
 - [MarkovChain](#markov-chain)
+- [DeepMarkovChain](#deep-markov-chain)
 
 ## seed
 

--- a/docs/stochastic-methods.md
+++ b/docs/stochastic-methods.md
@@ -22,7 +22,7 @@ const Rand = require('total-serialism').Stochastic;
 - [pick](#pick)
 - [clave](#clave)
 - [expand](#expand)
-- [MarkovChain](#markovchain)
+- [MarkovChain](#markov-chain)
 
 ## seed
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A set of methods for the generation and transformation of number sequences useful in algorithmic composition",
   "main": "index.js",
   "scripts": {
-    "test": "jest test/serialism.test.js",
+    "test": "jest test/**.test.js",
     "build": "npm run database && npm run clean && npm run bundle && npm run build-es5 && npm run build-min",
     "clean": "rm -rf build",
     "bundle": "mkdir build && browserify --standalone TotalSerialism index.js > build/ts.bundle.js",

--- a/src/gen-stochastic.js
+++ b/src/gen-stochastic.js
@@ -406,4 +406,92 @@ class MarkovChain {
 		return c;
 	}
 }
-exports.MarkovChain = MarkovChain;
+
+class DeepMarkovChain {
+	constructor(data){
+		// transition probabilities table
+		this._table = new Map();
+		// train if dataset is provided
+		if (data) { this.train(data) };
+		// current state of markov chain
+		this._state = '';
+		// scoped random number generator
+		this.rng = seedrandom();
+	}
+	get table(){
+		// return copy of object
+		return this._table
+	}
+	clear(){
+		// empty the transition probabilities
+		this._table = new Map();
+	}
+	train(a, win){
+		if (!Array.isArray(a)){ 
+			return console.error('Error: train() expected array but received:', typeof a);
+		}
+		// build a transition table from array of values
+		for (let i=0; i < (a.length - win); i++) {
+			let slice = a.slice(i, i+win);
+			let key = JSON.stringify(slice);
+
+			let next = a[i+win]
+
+			if (this._table.has(key)) {
+				let arr = this._table.get(key)
+				arr.push(next)
+				this._table.set(key, arr)
+			} else {
+				this._table.set(key, [a[i+win]])
+			}
+		}
+	}
+	seed(s){
+		// set unpredictable seed if 0, null or undefined
+		if (s === 0 || s === null || s === undefined){
+			rng = seedrandom();
+		} else {
+			rng = seedrandom(s);
+		}
+	}
+	state(a){
+		// set the state
+		// stringify the state
+		let stringed = JSON.stringify(a)
+		if (!this._table.has(stringed)) {
+			console.error('Warning: state() value is not part of transition table');
+		}
+		this._state = stringed;
+	}
+	randomState() {
+		let keys = Array.from(this._table.keys())
+		this._state = keys[Math.floor(rng() * keys.length)]
+	}
+	next(){
+        // if the state is undefined or has no transition in table
+        // randomly choose from all
+		if (this._state === undefined || !this._table.has(this._state)) {
+			this.randomState()
+		}
+		// get probabilities based on state
+		let probs = this._table.get(this._state);
+		let newState = probs[Math.floor(rng() * probs.length)]
+
+		// Now recreate a nice string representation
+		let prefix = JSON.parse(this._state);
+		prefix.shift();
+		prefix.push(newState);
+		this._state = JSON.stringify(prefix);
+
+		return newState
+	}
+	chain(l){
+		// return an array of values generated with next()
+		let c = [];
+		for (let i=0; i<l; i++){
+			c.push(this.next());
+		}
+		return c;
+	}
+}
+exports.DeepMarkovChain = DeepMarkovChain;

--- a/test/markov.test.js
+++ b/test/markov.test.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+
+// test with different builds
+let entryPoint = "../index";
+// entryPoint = "../build/ts.bundle.js";
+// entryPoint = "../build/ts.es5.js";
+let es5build = "../build/ts.es5.min.js";
+
+// load library from index.js;
+let TS = require(entryPoint);
+
+// run full test with ./index.js
+fullTest(TS);
+
+// reload library with es5.min.js build
+// TS = require(es5build);
+
+// and run full test with es5.min.js build;
+// fullTest(TS);
+
+function fullTest(Srl) {
+	const Rand = Srl.Stochastic;
+
+	test("markov init properly", () => {
+		let markov = new Rand.DeepMarkovChain()
+		expect(markov).toBeDefined();
+	})
+
+	test("training works", () => {
+		let markov = new Rand.DeepMarkovChain()
+		markov.train([1, 2, 3, 4, 5, 6, 1, 2, 4], 2)
+		expect(markov._table.get(JSON.stringify([1, 2])))
+			.toStrictEqual([3, 4])
+		expect(markov._table.get(JSON.stringify([2, 3])))
+			.toStrictEqual([4])
+		expect(markov._table.get(JSON.stringify([3, 4])))
+			.toStrictEqual([5])
+		expect(markov._table.get(JSON.stringify([4, 5])))
+			.toStrictEqual([6])
+	})
+
+	test("iterating works", () => {
+		let markov = new Rand.DeepMarkovChain();
+		markov.train([1, 2, 3, 4], 2);
+		markov.state([1, 2])
+		expect(markov._state).toBe(
+			JSON.stringify(
+				[1, 2]
+			)
+		)
+		markov.next()
+		expect(markov._state).toBe(
+			JSON.stringify(
+				[2, 3]
+			)
+		)
+	})
+
+	test("unfound state can be handled", () => {
+		let markov = new Rand.DeepMarkovChain()
+		markov.train([1, 2, 3, 4], 2);
+		markov.next()
+		expect(markov._state).toBeDefined()
+	})
+
+	test("random state", () => {
+		let markov = new Rand.DeepMarkovChain()
+		markov.train([1, 2, 3, 4], 3)
+		markov.randomState();
+		const possible = [
+			JSON.stringify([1, 2, 3]),
+			JSON.stringify([2, 3, 4])
+		]
+		expect(possible).toContain(markov._state)
+	})
+}

--- a/test/markov.test.js
+++ b/test/markov.test.js
@@ -13,10 +13,10 @@ let TS = require(entryPoint);
 fullTest(TS);
 
 // reload library with es5.min.js build
-// TS = require(es5build);
+TS = require(es5build);
 
 // and run full test with es5.min.js build;
-// fullTest(TS);
+fullTest(TS);
 
 function fullTest(Srl) {
 	const Rand = Srl.Stochastic;


### PR DESCRIPTION
PR adds a new class `DeepMarkovChain`. Name is definitely not for sure and could be easily find+replace changed.

This new class can do markov chains at an arbitrary length. It builds its chain by converting arrays into strings via `JSON.stringify() and JSON.parse()`. There is a test suite that goes along with it, as well as documentation.

Feedback welcome!